### PR TITLE
Implement crossword cell colouring and hint state

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,6 +65,20 @@
     </div>
   </div>
 
+  <!-- Completion/share modal -->
+  <div id="shareModal" class="modal" hidden>
+    <div class="modal-card" role="dialog" aria-modal="true" aria-labelledby="shareHeading">
+      <button class="modal-close" id="shareClose" aria-label="Close">×</button>
+      <h2 id="shareHeading">Kia ora — you finished!</h2>
+      <p>I beat todays cryptic crossword!</p>
+      <div id="shareGrid" class="share-grid" aria-label="Result grid"></div>
+      <button class="help-button small" id="copyResult">Copy result</button>
+      <a class="help-button small" href="https://mvpgarden.vercel.app/" target="_blank" rel="noopener">mvpgarden.vercel.app</a>
+    </div>
+  </div>
+
+  <div id="copyToast" class="toast" hidden>Copied</div>
+
   <div id="fireworks" class="fireworks" aria-hidden="true"></div>
 
   <!-- Inline puzzle data & tooltips embedded -->

--- a/script.js
+++ b/script.js
@@ -34,7 +34,6 @@ const btnBack = document.getElementById('btnBack');
 
 // Additional controls
 const btnGiveUp = document.getElementById('btnGiveUp');
-const btnShare = document.getElementById('btnShare'); // removed in HTML; will be null
 
 // Share modal elements
 const shareModal = document.getElementById('shareModal');

--- a/script.js
+++ b/script.js
@@ -1,4 +1,4 @@
-// script.js — loads straight to game, menu/welcome/share removed
+// Main game logic; starts directly in game view (menu/welcome/share stripped)
 const FILE = 'Clues.json';
 
 // Elements

--- a/script.js
+++ b/script.js
@@ -54,6 +54,19 @@ const TIP = {
   lit: 'Whole clue is both definition and wordplay.'
 };
 
+// Mapping from clue numbers to their highlight colours. Both the across and
+// down clues with the same number share a colour.
+const NUMBER_COLOURS = { '1': 'green', '2': 'yellow', '3': 'purple' };
+
+// Actual colour values used when rendering the grid.  These are fairly light so
+// that the black text remains legible over them.
+const BASE_COLOUR_VALUES = {
+  green: '#a8e6a8',
+  yellow: '#fff59d',
+  purple: '#d8b4fe'
+};
+const GREY_VALUE = '#bbb';
+
 function key(r,c){ return `${r},${c}`; }
 
 // ----- Grid build -----
@@ -68,7 +81,20 @@ function buildGrid(){
     const rowArr = [];
     for (let c=0;c<cols;c++){
       const k = key(r,c);
-      const cell = { r,c, block:blockSet.has(k), letter:'', entries:[], el:document.createElement('div'), nums:[] };
+      const cell = {
+        r,c,
+        block:blockSet.has(k),
+        letter:'',
+        // baseColour: "none" until a clue covering this cell is solved.
+        baseColour: 'none',
+        // isGrey marks whether a hint has touched this cell.
+        isGrey: false,
+        // locked letters cannot be overwritten once the clue is solved.
+        locked: false,
+        entries:[],
+        el:document.createElement('div'),
+        nums:[]
+      };
       cell.el.className = 'cell' + (cell.block ? ' block' : '');
       cell.el.setAttribute('role','gridcell');
       if (!cell.block) cell.el.addEventListener('click', () => handleCellClick(k));
@@ -101,7 +127,9 @@ function placeEntries(){
     answer: e.answer.toUpperCase(),
     clue: e.clue,
     cells: [],
-    iActive: 0
+    iActive: 0,
+    // Track whether the clue has been solved.
+    status: 'unsolved'
   }));
 
   entries.forEach(ent => {
@@ -114,6 +142,61 @@ function placeEntries(){
       cell.entries.push(ent);
     }
   });
+}
+
+// ----- Events -----
+// Return the highlight colour for a given clue id.
+function colourForClue(id){
+  const num = (id.match(/^\d+/) || [])[0];
+  return NUMBER_COLOURS[num] || null;
+}
+
+// Called when a clue is solved.  Colours the cells of the clue according to the
+// mapping above but never overwrites an existing baseColour.
+function onClueSolved(clueId){
+  const ent = entries.find(e => e.id === clueId);
+  if (!ent || ent.status === 'solved') return;
+  ent.status = 'solved';
+  const colour = colourForClue(clueId);
+  ent.cells.forEach(cell => {
+    if (colour && cell.baseColour === 'none') cell.baseColour = colour;
+    // lock the cell so its letter cannot be changed
+    cell.locked = true;
+  });
+  renderLetters();
+}
+
+// Called when a hint is used on a clue.  For non reveal-letter hints we simply
+// grey out a random cell.  For reveal-letter hints we also fill in the correct
+// letter for one not-yet-correct cell.
+function onHintUsed(clueId, type){
+  const ent = entries.find(e => e.id === clueId);
+  if (!ent || ent.status === 'solved') return;
+
+  if (type === 'reveal-letter'){
+    const candidates = ent.cells
+      .map((c,i) => ({ cell:c, idx:i }))
+      .filter(({cell, idx}) => (cell.letter || '').toUpperCase() !== ent.answer[idx]);
+    if (!candidates.length) return;
+    const { cell, idx } = candidates[Math.floor(Math.random()*candidates.length)];
+    cell.letter = ent.answer[idx];
+    cell.isGrey = true;
+    ent.iActive = idx;
+    activeCellKey = key(cell.r, cell.c);
+  } else {
+    const candidates = ent.cells.filter(c => !c.isGrey);
+    const cell = (candidates.length
+      ? candidates[Math.floor(Math.random()*candidates.length)]
+      : ent.cells[Math.floor(Math.random()*ent.cells.length)]);
+    cell.isGrey = true;
+  }
+  checkIfSolved(ent);
+  renderLetters();
+}
+
+function checkIfSolved(ent){
+  const guess = ent.cells.map(c => c.letter || '').join('').toUpperCase();
+  if (guess === ent.answer.toUpperCase()) onClueSolved(ent.id);
 }
 
 function renderClue(ent){
@@ -145,7 +228,16 @@ function renderLetters(){
       cell.el.removeChild(n);
     });
     cell.el.classList.remove('active');
+    if (cell.block) return;
+
+    // Apply colouring rules.  Grey overlay takes precedence over baseColour.
+    let bg = '#fff';
+    if (cell.isGrey) bg = GREY_VALUE;
+    else if (cell.baseColour !== 'none') bg = BASE_COLOUR_VALUES[cell.baseColour];
+    cell.el.style.background = bg;
+    cell.el.style.color = '#000'; // keep text legible over grey
   });
+
   grid.flat().forEach(cell => {
     if (cell.letter) {
       const d = document.createElement('div');
@@ -171,6 +263,9 @@ function setCurrentEntry(ent, fromCellKey=null){
     ent.iActive = (i>=0 ? i : 0);
   } else if (ent.iActive==null){
     ent.iActive = 0;
+  }
+  if (ent.cells[ent.iActive].locked) {
+    nextCell(+1) || nextCell(-1);
   }
   const cell = ent.cells[ent.iActive];
   activeCellKey = key(cell.r,cell.c);
@@ -200,8 +295,11 @@ function handleCellClick(k){
 
 function nextCell(inc){
   if (!currentEntry) return null;
-  let i = currentEntry.iActive + inc;
-  i = Math.max(0, Math.min(i, currentEntry.cells.length-1));
+  let i = currentEntry.iActive;
+  do {
+    i += inc;
+  } while (i >= 0 && i < currentEntry.cells.length && currentEntry.cells[i].locked);
+  if (i < 0 || i >= currentEntry.cells.length) return null;
   currentEntry.iActive = i;
   const cell = currentEntry.cells[i];
   activeCellKey = key(cell.r,cell.c);
@@ -210,15 +308,24 @@ function nextCell(inc){
 
 function typeChar(ch){
   if (!currentEntry) return;
-  const cell = currentEntry.cells[currentEntry.iActive];
+  let cell = currentEntry.cells[currentEntry.iActive];
+  if (cell.locked){
+    cell = nextCell(+1);
+    if (!cell || cell.locked) return;
+  }
   cell.letter = ch.toUpperCase();
+  checkIfSolved(currentEntry);
   nextCell(+1);
   renderLetters();
 }
 
 function backspace(){
   if (!currentEntry) return;
-  const cell = currentEntry.cells[currentEntry.iActive];
+  let cell = currentEntry.cells[currentEntry.iActive];
+  if (cell.locked){
+    cell = nextCell(-1);
+    if (!cell || cell.locked) return;
+  }
   cell.letter = '';
   nextCell(-1);
   renderLetters();
@@ -229,6 +336,7 @@ function submitAnswer(){
   const guess = currentEntry.cells.map(c => c.letter||' ').join('').toUpperCase();
   const target = currentEntry.answer.toUpperCase();
   if (guess === target){
+    onClueSolved(currentEntry.id);
     game.classList.add('flash-green');
     setTimeout(() => {
       game.classList.remove('flash-green');
@@ -267,20 +375,18 @@ function setupHandlers(){
     }
   });
   if (btnHintDef) btnHintDef.addEventListener('click', () => {
-    clueTextEl.classList.toggle('help-on');
+    if (!currentEntry) return;
+    const shown = clueTextEl.classList.toggle('help-on');
+    if (shown) onHintUsed(currentEntry.id, 'definition');
   });
   if (btnHintLetter) btnHintLetter.addEventListener('click', () => {
     if (!currentEntry) return;
-    const empties = currentEntry.cells.map((c,i)=>c.letter?null:i).filter(i=>i!==null);
-    if (!empties.length) return;
-    const idx = empties[Math.floor(Math.random()*empties.length)];
-    currentEntry.cells[idx].letter = currentEntry.answer[idx];
-    currentEntry.iActive = idx;
-    activeCellKey = key(currentEntry.cells[idx].r, currentEntry.cells[idx].c);
-    renderLetters();
+    onHintUsed(currentEntry.id, 'reveal-letter');
   });
   if (btnHintAnalyse) btnHintAnalyse.addEventListener('click', () => {
-    clueTextEl.classList.toggle('annot-on');
+    if (!currentEntry) return;
+    const shown = clueTextEl.classList.toggle('annot-on');
+    if (shown) onHintUsed(currentEntry.id, 'analyse');
   });
 
   // Top Menu dropdown — removed; guards keep this safe if elements don't exist
@@ -357,7 +463,15 @@ function setupHandlers(){
   });
 }
 function restartGame(){
-  entries.forEach(ent => ent.cells.forEach(c => { c.letter = ''; }));
+  entries.forEach(ent => {
+    ent.status = 'unsolved';
+    ent.cells.forEach(c => {
+      c.letter = '';
+      c.baseColour = 'none';
+      c.isGrey = false;
+      c.locked = false;
+    });
+  });
   setCurrentEntry(entries[0]);
   renderLetters();
 }

--- a/script.js
+++ b/script.js
@@ -1,4 +1,4 @@
-// Main game logic; starts directly in game view (menu/welcome/share stripped)
+// Main game logic; starts directly in game view
 const FILE = 'Clues.json';
 
 // Elements

--- a/style.css
+++ b/style.css
@@ -132,3 +132,28 @@ body{margin:0; background:var(--bg); color:var(--fg);
 .modal-close{ position:sticky; top:0; float:right; margin-left:auto; border:0; background:transparent; color:#fff; font-size:2rem; cursor:pointer }
 .fireworks{ position:fixed; inset:0; pointer-events:none }
 .pixel{ position:absolute; width:2px; height:2px; background:#fff }
+
+/* Share modal preview grid */
+.share-grid{
+  display:grid;
+  grid-template-columns:repeat(5,16px);
+  grid-template-rows:repeat(5,16px);
+  gap:2px;
+  margin:1rem auto;
+}
+.share-cell{
+  width:16px; height:16px; border:1px solid #444;
+}
+
+/* Copy toast */
+.toast{
+  position:fixed;
+  left:50%;
+  bottom:1rem;
+  transform:translateX(-50%);
+  background:#333;
+  color:#fff;
+  padding:.4rem .8rem;
+  border-radius:8px;
+  font-size:.9rem;
+}


### PR DESCRIPTION
## Summary
- Track per-cell base colours, grey hint markings, and locked status
- Lock cell letters on clue solve and automatically colour when answers are completed
- Skip locked cells during navigation and input for immediate feedback

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b43a5a5a94832ba5b373be3488ad47