### PR TITLE
Fix syntax errors preventing puzzle from loading

### DIFF
--- a/script.js
+++ b/script.js
@@ -320,10 +320,7 @@ function closeShareModal(){
   if (shareModal._trap) shareModal.removeEventListener('keydown', shareModal._trap);
   if (lastFocused) lastFocused.focus();
 
-  }
-
   renderLetters();
-
 }
 
 function renderClue(ent){
@@ -618,9 +615,6 @@ function restartGame(){
   if (copyToast) copyToast.hidden = true;
   const fireworks = document.getElementById('fireworks');
   if (fireworks) fireworks.classList.remove('on');
-
-    });
-  });
 
   setCurrentEntry(entries[0]);
   renderLetters();


### PR DESCRIPTION
## Summary
- Remove stray closing braces in `closeShareModal` and `restartGame`
- Ensure restart logic and share modal close correctly render and reset grid

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5221d579c832bafa09bb10551a764